### PR TITLE
Add redirect=no to ajax request url in case of redirecting category

### DIFF
--- a/src/utils/api/categoryMembers.ts
+++ b/src/utils/api/categoryMembers.ts
@@ -84,7 +84,7 @@ const getCategoryMembers = async (cmtitle: string, cmtype: Cmtype[] = ['page', '
       }
     };
 
-    await getCategoryMembersByAjax(`/${cmtitle}?useskin=vector&safemode=1`);
+    await getCategoryMembersByAjax(`/${cmtitle}?useskin=vector&safemode=1&redirect=no`);
   }
   return pageList;
 };


### PR DESCRIPTION
如题，目前用AJAX请求分类页时无法处理已重定向的分类（会自动跳转到重定向目标分类的页面）。